### PR TITLE
Add automatic verification tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get -y install openssl
 
 COPY deployer/create_manifests.sh /bin/
 COPY deployer/deploy.sh /bin/
+COPY deployer/deploy_with_tests.sh /bin/
 COPY schema.yaml /data/
+COPY schema-test.yaml /data/schema.yaml
 COPY server.config /data/
 COPY manifest /data/manifest
 COPY manifest-ingress /data/manifest-ingress

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-#GCP_PROJECT=cloud-bill-dev
-GCP_PROJECT=cjp-marketplace-dev
-
 #Registries
 GCR_REGISTRY_PATH=gcr.io/$(GCP_PROJECT)/cloudbees-core-billable
 CORE_REGISTRY_PATH=cloudbees
@@ -123,7 +120,7 @@ install: install-app-crd deployer check-license-params
 	--parameters='{"name": "$(NAME)", "namespace": "$(NAMESPACE)", "numberOfUsers": "$(NUMBER_OF_USERS)", \
 	"customerFirstName": "$(CUSTOMER_FIRST_NAME)", "customerLastName": "$(CUSTOMER_LAST_NAME)", \
 	"customerEmail": "$(CUSTOMER_EMAIL)", "customerCompany": "$(CUSTOMER_COMPANY)", \
-	"reportingSecret": ""}'
+	"reportingSecret": "gs://cloud-marketplace-tools/reporting_secrets/fake_reporting_secret.yaml"}'
 
 uninstall:
 	kubectl delete ns cloudbees-core

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+#GCP_PROJECT=cloud-bill-dev
+GCP_PROJECT=cjp-marketplace-dev
+
 #Registries
 GCR_REGISTRY_PATH=gcr.io/$(GCP_PROJECT)/cloudbees-core-billable
 CORE_REGISTRY_PATH=cloudbees
@@ -120,7 +123,7 @@ install: install-app-crd deployer check-license-params
 	--parameters='{"name": "$(NAME)", "namespace": "$(NAMESPACE)", "numberOfUsers": "$(NUMBER_OF_USERS)", \
 	"customerFirstName": "$(CUSTOMER_FIRST_NAME)", "customerLastName": "$(CUSTOMER_LAST_NAME)", \
 	"customerEmail": "$(CUSTOMER_EMAIL)", "customerCompany": "$(CUSTOMER_COMPANY)", \
-	"reportingSecret": "gs://cloud-marketplace-tools/reporting_secrets/fake_reporting_secret.yaml"}'
+	"reportingSecret": ""}'
 
 uninstall:
 	kubectl delete ns cloudbees-core

--- a/deployer/deploy_with_tests.sh
+++ b/deployer/deploy_with_tests.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INGRESS_IP=127.0.0.1
+
+set -eox pipefail
+
+get_domain_name() {
+  echo "$NAME.$INGRESS_IP.beesdns.com"
+}
+
+# Installs CloudBees Core
+apply_cloudbees_core_manifest() {
+    local manifest_file=${1:?} #first arg should be manifest location
+    kubectl apply -f "$manifest_file"
+}
+
+# Installs ingress controller
+install_ingress_controller() {
+    if [[ -z $(kubectl get svc | grep $NAME-ingress-nginx ) ]]; then
+      local manifest_file=${1:?} #first arg should be manifest location
+      kubectl apply -f "$manifest_file"
+      echo "Installed ingress controller."
+    else
+      echo "Ingress controller already exists."
+    fi
+    
+    while [[ "$(kubectl get svc ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" = '' ]]; do sleep 3; done
+    INGRESS_IP=$(kubectl get svc ingress-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}' | sed 's/"//g')
+    echo "NGINX INGRESS: $INGRESS_IP"
+}
+
+# Installs ingress controller op
+install_ingress_controller_op() {
+    local manifest_file=${1:?} #first arg should be manifest location
+    kubectl apply -f "$manifest_file"
+    echo "Installed ingress controller on gke op."
+}
+
+#create self-signed cert
+create_cert(){
+  local config_file=/data/server.config
+
+  #override placeholder domain name with actual domain name
+  sed -i -e "s#cloudbees-core.example.com#$(get_domain_name)#" "$config_file"
+
+  #create self-signed cert
+  openssl req -config "$config_file" -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr
+  echo "Created server.key"
+  echo "Created server.csr"
+  openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+  echo "Created server.crt (self-signed)"
+
+  #create k8s secret which contains cert and key
+  kubectl create secret tls $NAME-tls --cert=server.crt --key=server.key
+}
+
+deploy_gke_cloud(){
+  echo "Deploying onto GKE cloud."
+  sed -i '/\$loadBalancerIp/d' "/data/nginx.yaml"
+  install_ingress_controller "/data/nginx.yaml"
+  create_cert
+  sed -i -e "s#\$publicHost#$NAME.$INGRESS_IP.beesdns.com#" "/data/cje.yaml"
+  apply_cloudbees_core_manifest "/data/cje.yaml"
+}
+
+deploy_gke_op(){
+  echo "Deploying onto GKE on-prem."
+  install_ingress_controller_op "/data/nginx.yaml"
+  sed -i '/tls:/,+3d' "/data/cje.yaml"
+  sed -i '/ssl-redirect/d' "/data/cje.yaml"
+  sed -i 's/https/http/' "/data/cje.yaml"
+  apply_cloudbees_core_manifest "/data/cje.yaml"
+}
+
+# If any command returns with non-zero exit code, set -e will cause the script
+# to exit. Prior to exit, set App assembly status to "Failed".
+handle_failure() {
+  code=$?
+  if [[ -z "$NAME" ]] || [[ -z "$NAMESPACE" ]]; then
+    # /bin/expand_config.py might have failed.
+    # We fall back to the unexpanded params to get the name and namespace.
+    NAME="$(/bin/print_config.py \
+            --xtype NAME \
+            --values_mode raw)"
+    NAMESPACE="$(/bin/print_config.py \
+            --xtype NAMESPACE \
+            --values_mode raw)"
+    export NAME
+    export NAMESPACE
+  fi
+  patch_assembly_phase.sh --status="Failed"
+  exit $code
+}
+
+trap "handle_failure" EXIT
+
+NAME="$(/bin/print_config.py \
+    --xtype NAME \
+    --values_mode raw)"
+NAMESPACE="$(/bin/print_config.py \
+    --xtype NAMESPACE \
+    --values_mode raw)"
+export NAME
+export NAMESPACE
+
+echo "Deploying application \"$NAME\" in testing mode (mikec!)"
+
+app_uid=$(kubectl get "applications.app.k8s.io/$NAME" \
+  --namespace="$NAMESPACE" \
+  --output=jsonpath='{.metadata.uid}')
+echo "App UID: ${app_uid}"
+app_api_version=$(kubectl get "applications.app.k8s.io/$NAME" \
+  --namespace="$NAMESPACE" \
+  --output=jsonpath='{.apiVersion}')
+echo "App API version: ${app_api_version}"
+
+#set values from schema.yaml as environment variables
+/bin/expand_config.py --values_mode raw --app_uid "$app_uid"
+#merge manifests with environment variables
+create_manifests.sh
+
+# Assign owner references for the resources.
+/bin/set_ownership.py \
+  --app_name "$NAME" \
+  --app_uid "$app_uid" \
+  --app_api_version "$app_api_version" \
+  --manifests "/data/manifest-expanded" \
+  --dest "/data/cje.yaml"
+
+/bin/set_ownership.py \
+  --app_name "$NAME" \
+  --app_uid "$app_uid" \
+  --app_api_version "$app_api_version" \
+  --manifests "/data/manifest-ingress-expanded" \
+  --dest "/data/nginx.yaml"
+
+# Ensure assembly phase is "Pending", until successful kubectl apply.
+/bin/setassemblyphase.py \
+  --manifest "/data/cje.yaml" \
+  --status "Pending"
+
+/bin/setassemblyphase.py \
+  --manifest "/data/nginx.yaml" \
+  --status "Pending"
+
+
+if grep -q '$loadBalancerIp' "/data/nginx.yaml" ; then
+  deploy_gke_cloud
+else
+  deploy_gke_op
+fi
+
+sleep 20
+
+patch_assembly_phase.sh --status="Success"
+
+clean_iam_resources.sh
+
+trap - EXIT

--- a/deployer/deploy_with_tests.sh
+++ b/deployer/deploy_with_tests.sh
@@ -164,7 +164,9 @@ else
   deploy_gke_op
 fi
 
-sleep 20
+sleep 180
+
+# add some actual tests here
 
 patch_assembly_phase.sh --status="Success"
 

--- a/schema-test.yaml
+++ b/schema-test.yaml
@@ -1,0 +1,199 @@
+application_api_version: v1beta1
+properties:
+  name:
+    type: string
+    x-google-marketplace:
+     type: NAME
+  namespace:
+    type: string
+    x-google-marketplace:
+      type: NAMESPACE
+  publicHost:
+    type: string
+    title: Public host name (ON-PREMISE ONLY)
+    description: Must be a valid DNS name. For IP addresses add beesdns.com. eg. 139.178.70.46.beesdns.com This is only required for on-premise only. For cloud GKE, skip this field and this is assigned automatically.
+    pattern: ^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$
+  loadBalancerIp:
+    type: string
+    title: Load balancer IP (ON-PREMISE ONLY)
+    description: This is only required for on-premise only. For cloud GKE, skip this field and this is assigned automatically.
+    pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
+  cjocImage:
+    type: string
+    description: This is the CloudBees Core Operations Center image.
+    default: gcr.io/cje-marketplace-dev/cloudbees-core-billable:2.176
+    x-google-marketplace:
+      type: IMAGE
+  mmImage:
+    type: string
+    description: This is the Jenkins Managed Master image.
+    default: gcr.io/cje-marketplace-dev/cloudbees-core-billable/cloudbees-core-mm:2.176
+    x-google-marketplace:
+      type: IMAGE
+  nginxIngressImage:
+    type: string
+    description: This is an image for the nginx ingress controller.
+    default: gcr.io/cje-marketplace-dev/cloudbees-core-billable/nginx-ingress-controller:2.176
+    x-google-marketplace:
+      type: IMAGE
+  nginxIngressServiceAccount:
+    title: NGINX Ingress Service account name
+    type: string
+    description: This is the name of the ServiceAccount that is used to deploy the NGINX Ingress Controller.
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        roles:
+          - type: Role
+            rulesType: CUSTOM
+            rules:
+              - apiGroups: [""]
+                resources: ["namespaces"]
+                verbs: ["get"]
+              - apiGroups: [""]
+                resources: ["configmaps", "pods", "secrets", "endpoints"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources: ["services"]
+                verbs: ["get", "list", "update", "watch"]
+              - apiGroups: ["extensions"]
+                resources: ["ingresses"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["extensions"]
+                resources: ["ingresses/status"]
+                verbs: ["update"]
+              - apiGroups: [""]
+                resourceNames: ["ingress-controller-leader-nginx"]
+                resources: ["configmaps"]
+                verbs: ["get", "update"]
+              - apiGroups: [""]
+                resources: ["configmaps"]
+                verbs: ["create"]
+              - apiGroups: [""]
+                resources: ["endpoints"]
+                verbs: ["create", "get", "update"]
+              - apiGroups: [""]
+                resources: ["events"]
+                verbs: ["create", "patch"]
+          - type: ClusterRole
+            rulesType: CUSTOM
+            rules:
+              - apiGroups: [""]
+                resources: ["configmaps", "endpoints", "nodes", "pods", "secrets"]
+                verbs: ["list", "watch"]
+              - apiGroups: [""]
+                resources: ["nodes"]
+                verbs: ["get"]
+              - apiGroups: [""]
+                resources: ["services"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources: ["events"]
+                verbs: ["create", "update"]
+              - apiGroups: ["extensions", "networking.k8s.io"]
+                resources: ["ingresses"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: ["extensions", "networking.k8s.io"]
+                resources: ["ingresses/status"]
+                verbs: ["update"]
+  operationsCenterServiceAccount:
+    title: Operations Center Service account name
+    type: string
+    description: This is the name of the ServiceAccount that is used to deploy CloudBees Core Operations Center.
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        roles:
+        - type: Role
+          rulesType: CUSTOM
+          rules:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: [""]
+              resources: ["pods/exec"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: [""]
+              resources: ["pods/log"]
+              verbs: ["get","list","watch"]
+            - apiGroups: ["apps"]
+              resources: ["statefulsets"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: [""]
+              resources: ["services"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: [""]
+              resources: ["persistentvolumeclaims"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: ["extensions"]
+              resources: ["ingresses"]
+              verbs: ["create","delete","get","list","patch","update","watch"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["list"]
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["get","list","watch"]
+  masterServiceAccount:
+    title: Managed Master Service account name
+    type: string
+    description: This is the name of the ServiceAccount that is used to deploy CloudBees Core Managed Masters.
+    x-google-marketplace:
+      type: SERVICE_ACCOUNT
+      serviceAccount:
+        roles:
+          - type: Role
+            rulesType: CUSTOM
+            rules:
+              - apiGroups: [""]
+                resources: ["pods"]
+                verbs: ["create","delete","get","list","patch","update","watch"]
+              - apiGroups: [""]
+                resources: ["pods/exec"]
+                verbs: ["create","delete","get","list","patch","update","watch"]
+              - apiGroups: [""]
+                resources: ["pods/log"]
+                verbs: ["get","list","watch"]
+  imageUbbagent:
+    type: string
+    default: gcr.io/cje-marketplace-dev/cloudbees-core-billable/ubbagent:2.176
+    x-google-marketplace:
+      type: IMAGE
+  imageReportingFunction:
+    type: string
+    default: gcr.io/cje-marketplace-dev/cloudbees-core-billable/reporting-function:2.176
+    x-google-marketplace:
+      type: IMAGE
+  reportingSecret:
+    type: string
+    x-google-marketplace:
+      type: REPORTING_SECRET
+  numberOfUsers:
+    title: Number of Users
+    type: integer
+    default: 10
+    minimum: 10
+  customerFirstName:
+    title: Customer's first name (for licensing)
+    type: string
+    default: Thomas
+  customerLastName:
+    title: Customer's last name (for licensing)
+    type: string
+    default: Tester
+  customerEmail:
+    title: Customer's email address (for licensing)
+    type: string
+    default: test@test.com
+  customerCompany:
+    title: Customer's company name (for licensing)
+    type: string
+    default: We love to test!
+required:
+- name
+- namespace
+- numberOfUsers
+- customerFirstName
+- customerLastName
+- customerEmail
+- customerCompany


### PR DESCRIPTION
WIP

To test locally, set `GCP_PROJECT` to something suitable, then :

`make core-oc; make core-mm; make nginx; make deployer; make ubbagent; make install-app-crd`

which should ensure that all the needed images are available in your registry.  Then you can run the test like this:

```
mpdev verify --deployer=gcr.io/cirioli-marketplace-dev/cloudbees-core-billable/deployer@sha256:191101815db7419e876efc85f4ac55d4956eb081a67a72e44798aacbae0b66c4`
```

You will want to replace the deployer image with the location and sha256 hash of the one you just pushed in the first step.  If you make any changes to the deployer bits, you will need to re-run `make deployer` and update the sha256 hash of the image used by `mpdev`
